### PR TITLE
fix issue of array being merged

### DIFF
--- a/Model/MagentoRequest.php
+++ b/Model/MagentoRequest.php
@@ -53,7 +53,9 @@ class MagentoRequest extends RemoteRequest implements MagentoRequestInterface
         $searchParams = [];
         foreach ($searchCriteriaData as $key => $val) {
             if ($key === 'filterGroups' && is_array($val)) {
-                $searchParams += $this->mapSearchCriteriaFilterGroup($val);
+                foreach($this->mapSearchCriteriaFilterGroup($val) as $filterCriteria) {
+                    $searchParams[] = $filterCriteria;
+                }
             } elseif (is_string($val) || is_numeric($val)) {
                 $searchParams[] = 'searchCriteria[' . $key . ']' . '=' . $val;
             }
@@ -62,7 +64,7 @@ class MagentoRequest extends RemoteRequest implements MagentoRequestInterface
         return $uri . implode('&', $searchParams);
     }
 
-    protected function mapSearchCriteriaFilterGroup(array $filterGroups)
+    protected function mapSearchCriteriaFilterGroup(array $filterGroups): array
     {
         $searchParams = [];
         foreach ($filterGroups as $groupId => $filters) {


### PR DESCRIPTION
when doing `$searchParams += $this->mapSearchCriteriaFilterGroup($val);` two arrays are merged and the index of the later array is lost.

For eg. 
```php
$a = [0 => 0, 1 => 1, 2 => 2];
$a += [0 => 345];

// Result = [0 => 345, 1 => 1, 2 => 2]

```

this results in loss of search criteria when filter is applied 